### PR TITLE
Fix `TypeError` regarding wrong number of positional arguments.

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,7 @@ def jira_webhook():
 @app.route("/pagerduty-sync", methods=["POST"])
 def cron():
     try:
-        response = pd_cron.run()
+        response = pd_cron.run(None, None)
         response['ok'] = True
     except Exception as e:
         logger.exception('Error occurred during processing of a PagerDuty sync')

--- a/pd_cron.py
+++ b/pd_cron.py
@@ -27,7 +27,7 @@ else:
 logger = logging.getLogger()
 
 
-def run():
+def run(event, context):
     """
     Detect and synchronize PagerDuty incidents, if user changes Priority field
     from non P-1 to P-1 value. In this case application creates a


### PR DESCRIPTION
In other words the changes fix the error "TypeError: run() takes 0
positional arguments but 2 were given".