### PR TITLE
Fix `no-unsafe-wildcard-iam-permissions` warning.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -17,7 +17,12 @@ provider:
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
       Resource:
-        - "*"
+        - Fn::GetAtt:
+            - IncidentsTable
+            - Arn
+        - Fn::GetAtt:
+            - LogEntriesTable
+            - Arn
   cronInterval: ${env:PAGERDUTY_CRON_INTERVAL}
   logEntriesPollingInterval: ${env:LOG_ENTRIES_POLL_INTERVAL}
   environment:


### PR DESCRIPTION
Fix "Wildcard resources in iamRoleStatements are not permitted."
warning that appears on deployment to qa environment.