### PR TITLE
Change the resource name.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -105,7 +105,7 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
-    ConfigTableName:
+    ConfigTable:
       Type: AWS::DynamoDB::Table
       Properties:
         TableName: ${self:custom.configTableName}


### PR DESCRIPTION
The name is correct but it is written using other convention than, for
instance, `IncidentsTable`. Thus changing it to be written using the
same convention.