### PR TITLE
Get rid of the routes for dev purposes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ serverless_sdk
 
 #Jetbrains
 .idea
+
+# custom routes for dev purposes
+/jpi/tools/dev_routes.py

--- a/jpi/app.py
+++ b/jpi/app.py
@@ -33,16 +33,12 @@ def jira_webhook():
     return jsonify(response)
 
 
-# The handler serves to 'manually' run of the polling function. It's useful for
-# development and/or support
-@app.route("/pagerduty-poll", methods=["POST"])
-def pagerduty_poll():
-    try:
-        response = polling.handler(None, None)
-        response["ok"] = True
-    except Exception as e:
-        logger.exception(
-            "Error occurred during processing of a PagerDuty poll"
-        )
-        response = {"ok": False, "error": repr(e)}
-    return jsonify(response)
+try:
+    # In some cases there is a need to use custom routes that are not
+    # needed for the project but for development purposes only. If you
+    # need them, please attach them to `dev_routes` blueprint that is
+    # defined in the module `jpi.tools.dev_routes`.
+    from jpi.tools.dev_routes import dev_routes
+    app.register_blueprint(dev_routes)
+except ImportError:
+    pass


### PR DESCRIPTION
In order to define the routes for dev purposes you can use the following code as an example:

```
# jpi/tools/dev_routes.py

import logging

from flask import Blueprint, jsonify

from jpi import polling


logger = logging.getLogger(__name__)
dev_routes = Blueprint('dev_routes', __name__)


# The handler serves to 'manually' run of the polling function. It's useful for
# development and/or support
@dev_routes.route("/pagerduty-poll", methods=["POST"])
def pagerduty_poll():
    try:
        response = polling.handler(None, None)
        response["ok"] = True
    except Exception as e:
        logger.exception(
            "Error occurred during processing of a PagerDuty poll"
        )
        response = {"ok": False, "error": repr(e)}
    return jsonify(response)
```